### PR TITLE
feat: Add analysis generator for SAS and R

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,37 @@ python scripts/generate_cdash_crf.py --model CDASH_Model_v1.3.xlsx \
 Edit `build_domain_crf()` in the script to customise the table layout or add
 study branding or adjust fonts and orientation if needed.
 
+## Generating Analysis Code
+
+This project can also generate analysis code in SAS and R for various outputs.
+
+### Quickstart
+
+To generate an analysis script, run the `scripts/generate_analysis.py` script with the desired parameters. For example, to generate a SAS script for a demographics table from the ADSL dataset, run the following command:
+
+```bash
+python scripts/generate_analysis.py \
+    --language sas \
+    --dataset ADSL \
+    --output-type demographics \
+    --treatment-var TRT01A \
+    --output-file demog_table.sas
+```
+
+This will generate a SAS file named `demog_table.sas` in the current directory.
+
+### Options
+
+The following options are available for the `generate_analysis.py` script:
+
+| Option          | Description                                    | Default |
+| --------------- | ---------------------------------------------- | ------- |
+| `--language`    | Language for the generated code (sas or r)     |         |
+| `--dataset`     | Source dataset (e.g., ADSL)                    |         |
+| `--output-type` | Type of analysis output (e.g., Demographics)   |         |
+| `--treatment-var`| Treatment variable (e.g., TRT01A)              |         |
+| `--output-file` | Path to the output file                        |         |
+
 ## Generating Synthetic Datasets
 
 In addition to generating CRFs from the CDISC Library, this project can also generate synthetic CDISC-compliant datasets using the cdiscdataset.com API.

--- a/scripts/generate_analysis.py
+++ b/scripts/generate_analysis.py
@@ -1,0 +1,31 @@
+import click
+import sys
+import os
+
+# Add src to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from analysisgen.generator import AnalysisGenerator
+
+@click.command()
+@click.option('--language', type=click.Choice(['sas', 'r'], case_sensitive=False), required=True, help='Language for the generated code.')
+@click.option('--dataset', required=True, help='Source dataset (e.g., ADSL).')
+@click.option('--output-type', required=True, help='Type of analysis output (e.g., Demographics).')
+@click.option('--treatment-var', required=True, help='Treatment variable (e.g., TRT01A).')
+@click.option('--output-file', required=True, help='Path to the output file.')
+def generate(language, dataset, output_type, treatment_var, output_file):
+    """
+    Generates analysis code in SAS or R.
+    """
+    generator = AnalysisGenerator(language, dataset, output_type, treatment_var)
+    code = generator.generate_code()
+
+    try:
+        with open(output_file, 'w') as f:
+            f.write(code)
+        click.echo(f"Successfully generated {language.upper()} code in {output_file}")
+    except IOError as e:
+        click.echo(f"Error writing to file: {e}", err=True)
+
+if __name__ == '__main__':
+    generate()

--- a/src/analysisgen/generator.py
+++ b/src/analysisgen/generator.py
@@ -1,0 +1,50 @@
+"""
+Core module for the analysis generator.
+"""
+from . import r_templates, sas_templates
+
+
+class AnalysisGenerator:
+    """
+    A class to generate analysis code in SAS and R.
+    """
+    def __init__(self, language, dataset, output_type, treatment_var):
+        self.language = language
+        self.dataset = dataset
+        self.output_type = output_type
+        self.treatment_var = treatment_var
+
+    def generate_code(self):
+        """
+        Generates the analysis code.
+        """
+        if self.language.lower() == 'sas':
+            return self._generate_sas_code()
+        elif self.language.lower() == 'r':
+            return self._generate_r_code()
+        else:
+            raise ValueError("Unsupported language. Please choose 'sas' or 'r'.")
+
+    def _generate_sas_code(self):
+        """
+        Generates SAS code.
+        """
+        if self.output_type.lower() == 'demographics':
+            return sas_templates.DEMO_TABLE_TEMPLATE.format(
+                dataset=self.dataset,
+                treatment_var=self.treatment_var
+            )
+        else:
+            return "/* SAS code for this output type is not yet implemented. */"
+
+    def _generate_r_code(self):
+        """
+        Generates R code.
+        """
+        if self.output_type.lower() == 'demographics':
+            return r_templates.DEMO_TABLE_TEMPLATE.format(
+                dataset=self.dataset,
+                treatment_var=self.treatment_var
+            )
+        else:
+            return "# R code for this output type is not yet implemented."

--- a/src/analysisgen/r_templates.py
+++ b/src/analysisgen/r_templates.py
@@ -1,0 +1,43 @@
+"""
+R code templates for analysis generation.
+"""
+
+DEMO_TABLE_TEMPLATE = """
+# Title: Demographics Table
+# Dataset: {dataset}
+# Treatment Variable: {treatment_var}
+
+library(tidyverse)
+library(rtables)
+
+# Assuming '{dataset}.csv' is in the working directory
+data <- read.csv("{dataset}.csv")
+
+# Demographics: Sex by Treatment Arm
+sex_table <- data %>%
+  group_by({treatment_var}, SEX) %>%
+  summarise(n = n(), .groups = 'drop') %>%
+  pivot_wider(names_from = {treatment_var}, values_from = n, values_fill = 0)
+
+print("Demographics: Sex by Treatment Arm")
+print(sex_table)
+
+# Demographics: Age Summary by Treatment Arm
+age_summary <- data %>%
+  group_by({treatment_var}) %>%
+  summarise(
+    n = n(),
+    mean = mean(AGE, na.rm = TRUE),
+    sd = sd(AGE, na.rm = TRUE),
+    min = min(AGE, na.rm = TRUE),
+    max = max(AGE, na.rm = TRUE)
+  )
+
+print("Demographics: Age Summary by Treatment Arm")
+print(age_summary)
+
+# Note: RTF output in R requires additional packages and setup.
+# This example prints to the console. For a production-ready RTF,
+# you would typically use a package like 'rtables' or 'reporter'
+# and write the table objects to an RTF file.
+"""

--- a/src/analysisgen/sas_templates.py
+++ b/src/analysisgen/sas_templates.py
@@ -1,0 +1,24 @@
+"""
+SAS code templates for analysis generation.
+"""
+
+DEMO_TABLE_TEMPLATE = """
+* Title: Demographics Table;
+* Dataset: {dataset};
+* Treatment Variable: {treatment_var};
+
+ods rtf file="demographics.rtf";
+
+proc freq data={dataset};
+    tables {treatment_var}*sex / nocol nopercent;
+    title "Demographics: Sex by Treatment Arm";
+run;
+
+proc means data={dataset} n mean stddev min max;
+    class {treatment_var};
+    var age;
+    title "Demographics: Age Summary by Treatment Arm";
+run;
+
+ods rtf close;
+"""

--- a/tests/test_analysis_generator.py
+++ b/tests/test_analysis_generator.py
@@ -1,0 +1,59 @@
+import unittest
+import sys
+import os
+
+# Add src to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from analysisgen.generator import AnalysisGenerator
+
+class TestAnalysisGenerator(unittest.TestCase):
+
+    def test_generate_sas_code(self):
+        """
+        Test SAS code generation for demographics.
+        """
+        generator = AnalysisGenerator(
+            language='sas',
+            dataset='ADSL',
+            output_type='demographics',
+            treatment_var='TRT01A'
+        )
+        code = generator.generate_code()
+        self.assertIn('proc freq data=ADSL;', code)
+        self.assertIn('tables TRT01A*sex / nocol nopercent;', code)
+        self.assertIn('class TRT01A;', code)
+        self.assertIn('var age;', code)
+
+    def test_generate_r_code(self):
+        """
+        Test R code generation for demographics.
+        """
+        generator = AnalysisGenerator(
+            language='r',
+            dataset='ADSL',
+            output_type='demographics',
+            treatment_var='TRT01A'
+        )
+        code = generator.generate_code()
+        self.assertIn("library(tidyverse)", code)
+        self.assertIn("data <- read.csv(\"ADSL.csv\")", code)
+        self.assertIn("group_by(TRT01A, SEX)", code)
+        self.assertIn("group_by(TRT01A)", code)
+        self.assertIn("summarise(", code)
+
+    def test_unsupported_language(self):
+        """
+        Test that an unsupported language raises a ValueError.
+        """
+        with self.assertRaises(ValueError):
+            generator = AnalysisGenerator(
+                language='python',
+                dataset='ADSL',
+                output_type='demographics',
+                treatment_var='TRT01A'
+            )
+            generator.generate_code()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new feature that allows users to generate analysis code in both SAS and R.

The new analysis generator can be accessed via a command-line interface and supports the following features:
- Choice of language (SAS or R)
- Specification of source dataset (e.g., ADSL)
- Selection of output type (e.g., Demographics)
- Custom treatment variable
- RTF output for SAS

The implementation includes:
- A new `analysisgen` module to house the generator logic.
- SAS and R code templates for a demographics table.
- A CLI script (`scripts/generate_analysis.py`) for user interaction.
- Unit tests to verify the functionality of the generator.
- Updated documentation with instructions on how to use the new feature.
