### PR TITLE
feat: Add UI for generating analysis code

### DIFF
--- a/src/cdisc_generators/raw_dataset_package.py
+++ b/src/cdisc_generators/raw_dataset_package.py
@@ -1,0 +1,13 @@
+def generate_raw_dataset_package(num_subjects: int, therapeutic_area: str, domains: list, study_story: str, output_dir: str, output_format: str):
+    """
+    This is a placeholder function to allow the UI to run.
+    The original content of this file was lost.
+    """
+    print(f"Generating raw dataset package with the following parameters:")
+    print(f"  num_subjects: {num_subjects}")
+    print(f"  therapeutic_area: {therapeutic_area}")
+    print(f"  domains: {domains}")
+    print(f"  study_story: {study_story}")
+    print(f"  output_dir: {output_dir}")
+    print(f"  output_format: {output_format}")
+    pass

--- a/src/ui/static/js/main.js
+++ b/src/ui/static/js/main.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const syntheticForm = document.getElementById('synthetic-data-form');
     const rawForm = document.getElementById('raw-dataset-form');
+    const analysisForm = document.getElementById('analysis-code-form');
     const resultsOutput = document.getElementById('results-output');
 
     syntheticForm.addEventListener('submit', async (event) => {
@@ -37,6 +38,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
             const response = await fetch('/api/generate-raw-dataset-package', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            const result = await response.json();
+            resultsOutput.textContent = response.ok
+                ? `Success!\n\n${JSON.stringify(result, null, 2)}`
+                : `Error:\n\n${JSON.stringify(result, null, 2)}`;
+        } catch (error) {
+            resultsOutput.textContent = `An unexpected error occurred: ${error.message}`;
+        }
+    });
+
+    analysisForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        resultsOutput.textContent = 'Generating analysis code...';
+
+        const formData = new FormData(analysisForm);
+        const data = Object.fromEntries(formData.entries());
+
+        try {
+            const response = await fetch('/api/generate-analysis-code', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data),

--- a/src/ui/templates/index.html
+++ b/src/ui/templates/index.html
@@ -79,6 +79,40 @@
             </form>
         </div>
 
+        <div class="generator-section">
+            <h2>Generate Analysis Code</h2>
+            <form id="analysis-code-form">
+                <div class="form-group">
+                    <label for="language">Language:</label>
+                    <select id="language" name="language" required>
+                        <option value="sas">SAS</option>
+                        <option value="r">R</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="dataset_path">Dataset Path:</label>
+                    <input type="text" id="dataset_path" name="dataset_path" placeholder="e.g., output/ui_generated_data/DM.csv" required>
+                </div>
+                <div class="form-group">
+                    <label for="output_type">Output Type:</label>
+                    <select id="output_type" name="output_type" required>
+                        <option value="demographics">Demographics</option>
+                        <option value="disposition">Disposition</option>
+                        <option value="exposure">Exposure</option>
+                        <option value="teae_summary">TEAE Summary</option>
+                        <option value="teae_by_soc_pt">TEAE by SOC/PT</option>
+                        <option value="lab_shift">Lab Shift Table</option>
+                        <option value="vs_change">Vital Signs Change</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="treatment_var">Treatment Variable:</label>
+                    <input type="text" id="treatment_var" name="treatment_var" value="ARM" required>
+                </div>
+                <button type="submit">Generate Code</button>
+            </form>
+        </div>
+
         <div id="results-section">
             <h2>Results</h2>
             <pre id="results-output"></pre>


### PR DESCRIPTION
This commit adds a new feature to the web UI that allows users to generate analysis code (SAS or R) for a given dataset.

The following changes are included:
- A new API endpoint `/api/generate-analysis-code` in `src/ui/main.py`.
- A new form in `src/ui/templates/index.html` for submitting analysis code generation requests.
- Updated client-side logic in `src/ui/static/js/main.js` to handle the new form.
- A new unit test in `tests/test_ui.py` for the new API endpoint.

Note: This commit also includes a placeholder file for `src/cdisc_generators/raw_dataset_package.py`. The original content of this file was missing, and the placeholder was added to resolve an import error and allow the application to run.

## Description
Please include a summary of the change and the motivation.

## Related issue
Closes #<issue number>

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [ ] My code follows project style (black, isort, ruff)
- [ ] I added tests and they pass
- [ ] I updated documentation if needed
