### PR TITLE
Remove redundant sas_code command and generate_sas_code function

### DIFF
--- a/src/cdisc_data_symphony/cli/commands/generate.py
+++ b/src/cdisc_data_symphony/cli/commands/generate.py
@@ -26,23 +26,6 @@ def tfl_shell(
 
 
 @generate_app.command()
-def sas_code(
-    dataset: str = typer.Option(..., "--dataset", help="Source dataset (e.g., ADSL)"),
-    output_type: str = typer.Option(..., "--output-type", help="Type of analysis output (e.g., Demographics)"),
-    treatment_var: str = typer.Option(..., "--treatment-var", help="Treatment variable (e.g., TRT01A)"),
-    output_file: pathlib.Path = typer.Option(..., "--output-file", help="Path to the output file")
-):
-    """
-    Generates analysis code in SAS.
-    """
-    try:
-        generation_service.generate_sas_code(dataset, output_type, treatment_var, output_file)
-        console.print(f"Successfully generated SAS code in {output_file}")
-    except Exception as e:
-        console.print(f"Error: {e}", style="bold red")
-
-
-@generate_app.command()
 def edc_raw_dataset_package(
     num_subjects: int = typer.Option(50, "--num-subjects", help="Number of subjects (10-200)"),
     therapeutic_area: str = typer.Option("Oncology", "--therapeutic-area", help="Therapeutic area for the study"),

--- a/src/cdisc_data_symphony/core/generation_service.py
+++ b/src/cdisc_data_symphony/core/generation_service.py
@@ -42,22 +42,6 @@ def generate_tfl_shell(spec: str, output_file: pathlib.Path):
         f.write(shell)
 
 
-def generate_sas_code(dataset: str, output_type: str, treatment_var: str, output_file: pathlib.Path):
-    """
-    Generates analysis code in SAS.
-
-    Args:
-        dataset (str): The source dataset (e.g., "ADSL").
-        output_type (str): The type of analysis output (e.g., "Demographics").
-        treatment_var (str): The treatment variable (e.g., "TRT01A").
-        output_file (pathlib.Path): The path to the output file where the SAS code will be saved.
-    """
-    generator = AnalysisGenerator("sas", dataset, output_type, treatment_var)
-    code = generator.generate_code()
-    with open(output_file, 'w') as f:
-        f.write(code)
-
-
 def generate_edc_raw_dataset_package(num_subjects: int, therapeutic_area: str, domains: List[str], study_story: str, output_dir: pathlib.Path, output_format: str):
     """
     Generates an EDC (Electronic Data Capture) Raw Dataset Package.


### PR DESCRIPTION
The `sas_code` command in the CLI and the `generate_sas_code` function in the generation service were redundant. Their functionality was already covered by the more generic `analysis_code` command and `generate_analysis_code` function.

This change removes the redundant code to improve maintainability and reduce confusion.

## Description
Please include a summary of the change and the motivation.

## Related issue
Closes #<issue number>

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [ ] My code follows project style (black, isort, ruff)
- [ ] I added tests and they pass
- [ ] I updated documentation if needed
