### PR TITLE
fix(data-generator): Ensure _generate_date returns only date

### DIFF
--- a/src/cdisc_data_symphony/generators/data_generator.py
+++ b/src/cdisc_data_symphony/generators/data_generator.py
@@ -75,7 +75,7 @@ class DataGenerator:
         end_date = datetime(2023, 12, 31)
         delta = end_date - start_date
         random_days = random.randint(0, delta.days)
-        return (start_date + timedelta(days=random_days)).isoformat()
+        return (start_date + timedelta(days=random_days)).date().isoformat()
 
     def _generate_from_codelist(self, codelist):
         """

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -1,3 +1,4 @@
+import re
 from cdisc_data_symphony.generators.data_generator import DataGenerator
 from cdisc_data_symphony.generators.crfgen.schema import Form, FieldDef, Codelist
 
@@ -31,3 +32,19 @@ def test_generate_from_codelist():
     dataset = generator.generate(num_subjects=1)
 
     assert dataset[0]["SEX"] == "C123"
+
+
+def test_generate_date_format():
+    """
+    Tests that the DataGenerator generates a date in the correct format.
+    """
+    fields = [
+        FieldDef(oid="BRTHDTC", prompt="Birth Date", datatype="date", cdash_var="BRTHDTC"),
+    ]
+    form_data = Form(title="DM", domain="DM", fields=fields)
+    generator = DataGenerator(form_data)
+    dataset = generator.generate(num_subjects=1)
+    generated_date = dataset[0]["BRTHDTC"]
+
+    assert "T" not in generated_date
+    assert re.match(r"^\d{4}-\d{2}-\d{2}$", generated_date)


### PR DESCRIPTION
The `_generate_date` method in the `DataGenerator` class was returning a datetime string in ISO 8601 format including the time part (e.g., `YYYY-MM-DDTHH:MM:SS`).

This commit fixes the issue by calling `.date().isoformat()` on the datetime object, which ensures that only the date part is returned in `YYYY-MM-DD` format.

A new test case has been added to verify that the generated date string is in the correct format.

## Description
Please include a summary of the change and the motivation.

## Related issue
Closes #<issue number>

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [ ] My code follows project style (black, isort, ruff)
- [ ] I added tests and they pass
- [ ] I updated documentation if needed
